### PR TITLE
Ajoute page de pré-accueil et sons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <meta name="theme-color" content="#0a1018" />
 </head>
 <body>
+  <div id="preHome" class="pre-home">
+    <div class="pre-home-inner">
+      <h2>Propagande Vault-Tec</h2>
+      <p class="slogan">Construire un meilleur demain, aujourd’hui.</p>
+      <button id="connectBtn" class="btn primary">Connectez-vous aux services de l'abri 202</button>
+    </div>
+  </div>
   <!-- CRT overlay + scanlines -->
   <div class="crt"></div>
   <div class="noise"></div>

--- a/styles.css
+++ b/styles.css
@@ -211,3 +211,8 @@ body.terminal-mode{
   filter: contrast(1.15) saturate(1.25) brightness(1.05);
 }
 body.terminal-mode .crt{ opacity:.45 }
+
+/* Pre-home overlay */
+.pre-home{ position:fixed; inset:0; background:var(--bg); display:flex; align-items:center; justify-content:center; text-align:center; z-index:2001; flex-direction:column; padding:20px; }
+.pre-home .slogan{ color:var(--accent); margin:6px 0 16px; }
+.pre-home.is-hidden{ display:none; }


### PR DESCRIPTION
## Summary
- Ajout d'une page de pré-accueil avec bouton de connexion avant l'interface principale
- Activation des effets sonores fournis pour connexion, modale protégée, changement de thème et vérification de mot de passe
- Animation des lettres affichée ligne par ligne pour un effet rétro

## Testing
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba93643c8332aa8b45bc894c3f11