### PR TITLE
fix: Correct JavaScript syntax error in string assignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,7 +1448,7 @@ L’action se déroule dans l’univers post-apocalyptique de Fallout. Les bombe
                         typeWriter(contentData[tabId], () => {
                             if (tabId === 'superviseurH' || tabId === 'superviseurA') {
                                 const supervisorButton = document.createElement('button');
-                                supervisorButton.textContent = "Superviseur, merci de vous enregistrer "Enregistrement Biométrique"";
+                                supervisorButton.textContent = "Superviseur, merci de vous enregistrer 'Enregistrement Biométrique'";
                                 supervisorButton.classList.add('flashing-green-button');
 
                                 supervisorButton.addEventListener('click', () => {


### PR DESCRIPTION
A syntax error was introduced due to improper quoting of a string literal. This commit corrects the nested double quotes to single quotes to ensure the JavaScript is valid.